### PR TITLE
Fix binding for Dict.toArray

### DIFF
--- a/src/Js__Dict.res
+++ b/src/Js__Dict.res
@@ -13,7 +13,7 @@ let delete = (dict, string) => {
 @val external fromArray: array<(string, 'a)> => t<'a> = "Object.fromEntries"
 @val external fromIterator: Js__Iterator.t<(string, 'a)> => t<'a> = "Object.fromEntries"
 
-@val external toArray: t<'a> => array<'a> = "Object.entries"
+@val external toArray: t<'a> => array<(string, 'a)> = "Object.entries"
 
 @val external keysToArray: t<'a> => array<string> = "Object.keys"
 


### PR DESCRIPTION
Return type should be `array<(string, 't)>` instead of `array<'t>`: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries#return_value