### PR TITLE
Add Js.JSON.parseExnWithReviver and parseToAnyExnWithReviver

### DIFF
--- a/src/Js__JSON.res
+++ b/src/Js__JSON.res
@@ -16,11 +16,11 @@ external asJsonReplacer: 'a => jsonReplacer = "%identity"
 @val external parseToAnyExnWithReviver: (string, jsonReviver) => 'a = "JSON.parse"
 @val external stringifyAny: 'a => option<string> = "JSON.stringify"
 @val
-external stringifyAnyWithIndent: (t, @as(json`null`) _, int) => option<string> = "JSON.stringify"
+external stringifyAnyWithIndent: ('a, @as(json`null`) _, int) => option<string> = "JSON.stringify"
 @val
-external stringifyAnyWithReplacer: (t, jsonReplacer) => option<string> = "JSON.stringify"
+external stringifyAnyWithReplacer: ('a, jsonReplacer) => option<string> = "JSON.stringify"
 @val
-external stringifyAnyWithReplacerAndIndent: (t, jsonReplacer, int) => option<string> = "JSON.stringify"
+external stringifyAnyWithReplacerAndIndent: ('a, jsonReplacer, int) => option<string> = "JSON.stringify"
 
 module Decode = {
   type t =

--- a/src/Js__JSON.res
+++ b/src/Js__JSON.res
@@ -1,16 +1,26 @@
 type t = Js.Json.t
+
 type jsonReviver
+external asJsonReviver: 'a => jsonReviver = "%identity"
+type jsonReplacer
+external asJsonPlacer: 'a => jsonReplacer = "%identity"
 
 @val external parseExn: string => t = "JSON.parse"
 @val external parseExnWithReviver: (string, jsonReviver) => t = "JSON.parse"
 @val external stringify: t => string = "JSON.stringify"
 @val external stringifyWithIndent: (t, @as(json`null`) _, int) => string = "JSON.stringify"
+@val external stringifyWithReplacer: (t, jsonReplacer) => string = "JSON.stringify"
+@val external stringifyWithReplacerAndIndent: (t, jsonReplacer, int) => string = "JSON.stringify"
 
 @val external parseToAnyExn: string => 'a = "JSON.parse"
 @val external parseToAnyExnWithReviver: (string, jsonReviver) => 'a = "JSON.parse"
 @val external stringifyAny: 'a => option<string> = "JSON.stringify"
 @val
 external stringifyAnyWithIndent: (t, @as(json`null`) _, int) => option<string> = "JSON.stringify"
+@val
+external stringifyAnyWithReplacer: (t, jsonReplacer) => option<string> = "JSON.stringify"
+@val
+external stringifyAnyWithReplacerAndIndent: (t, jsonReplacer, int) => option<string> = "JSON.stringify"
 
 module Decode = {
   type t =

--- a/src/Js__JSON.res
+++ b/src/Js__JSON.res
@@ -1,10 +1,13 @@
 type t = Js.Json.t
+type jsonReviver
 
 @val external parseExn: string => t = "JSON.parse"
+@val external parseExnWithReviver: (string, jsonReviver) => t = "JSON.parse"
 @val external stringify: t => string = "JSON.stringify"
 @val external stringifyWithIndent: (t, @as(json`null`) _, int) => string = "JSON.stringify"
 
 @val external parseToAnyExn: string => 'a = "JSON.parse"
+@val external parseToAnyExnWithReviver: (string, jsonReviver) => 'a = "JSON.parse"
 @val external stringifyAny: 'a => option<string> = "JSON.stringify"
 @val
 external stringifyAnyWithIndent: (t, @as(json`null`) _, int) => option<string> = "JSON.stringify"

--- a/src/Js__JSON.res
+++ b/src/Js__JSON.res
@@ -3,7 +3,7 @@ type t = Js.Json.t
 type jsonReviver
 external asJsonReviver: 'a => jsonReviver = "%identity"
 type jsonReplacer
-external asJsonPlacer: 'a => jsonReplacer = "%identity"
+external asJsonReplacer: 'a => jsonReplacer = "%identity"
 
 @val external parseExn: string => t = "JSON.parse"
 @val external parseExnWithReviver: (string, jsonReviver) => t = "JSON.parse"


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#syntax
I had to make this binding for https://reverecre.github.io/relay-nextjs/docs/configuration#routing-integration (see end of the first example) and I think it could be here :)